### PR TITLE
remove jsdom and dompurify

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,8 +42,5 @@
     "react": "^16.8.4",
     "react-dom": "^16.8.4"
   },
-  "dependencies": {
-    "dompurify": "^1.0.5",
-    "jsdom": "^12.0.0"
-  }
+  "dependencies": {}
 }

--- a/src/IconInner.js
+++ b/src/IconInner.js
@@ -1,33 +1,15 @@
 import React, { PureComponent } from 'react';
 import PropTypes from 'prop-types';
-import DOMPurify from 'dompurify';
-import { JSDOM } from 'jsdom';
 // for now this icons json is generated via the build script from latest feather
 // TODO: automatically generate this JSON via this repo's build script
 import icons from './icons.json';
 
 class IconInner extends PureComponent {
   createMarkup(markup) {
-    // sanitize markup first:
-    const sanitizedMarkup = this.sanitizeMarkup(markup);
- 
-    // now do the weird thing for dangerouslySetInnerHTML
-    return { __html: sanitizedMarkup };
-  }
-
-  sanitizeMarkup(markup) {
-    // For server environement
-    if (!window) {
-      // We create a window out of JSDOM
-      const window = (new JSDOM('')).window;
-      // Then we plug it to DOMPurify
-      const DOMPurifyServer = DOMPurify(window);
-      // and finally sanitize the markup
-      return  DOMPurifyServer.sanitize(markup);
-    }
-
-    // Sanitize the markup
-    return  DOMPurify.sanitize(markup);
+    // we dont sanitize markup 
+    // since icons.json is maintained within the package before build
+    // do the weird thing for dangerouslySetInnerHTML
+    return { __html: markup };
   }
 
   render() {
@@ -38,8 +20,7 @@ class IconInner extends PureComponent {
 
     if (iconMarkup) {
       // i didnt want to use dangerouslySetInnerHTML
-      // but i am sanitizing the markup first
-      // and this way I can just use the JSON to spit out SVG
+      // but this way I can just use the JSON to spit out SVG.
       // another possible option is to use the feather lib functions
       // which create the SVG files, then an SVG loader could be used.
       // i am open to this for a future version.


### PR DESCRIPTION
These aren't really necessary and cause way more trouble than it's worth.

This is a second follow-up to this issue: https://github.com/ianmiller347/feather-icons-react/issues/4